### PR TITLE
ci: Use `PORT` environment variable to integrate with Render.com deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,13 +21,11 @@ RUN yarn
 # since it builds the server as well
 RUN yarn build
 
-# expose 5000 on container
-EXPOSE 5000
-
-# set app serving to permissive / assigned
-ENV NEXT_HOST=0.0.0.0
 # set app port
-ENV NEXT_PORT=5000
+ENV PORT=5000
+
+# expose 5000 on container
+EXPOSE $PORT
 
 # start the app
 RUN chmod +x start.sh

--- a/pages/index.js
+++ b/pages/index.js
@@ -66,13 +66,14 @@ const Home = ({ total_accounts, app_summary, app_total, apps}) => {
 }
 export async function getServerSideProps() {
 
-  let total_accounts = await fetch(`http://localhost:${process.env.NEXT_PORT || 3000}/api/v1/mainnet/accounts/total`)
+  let total_accounts = await fetch(`http://localhost:${process.env.NEXT_PORT || process.env.PORT || 3000}/api/v1/mainnet/accounts/total`)
   total_accounts = await total_accounts.json()
-  let app_summary = await fetch(`http://localhost:${process.env.NEXT_PORT || 3000}/api/v1/mainnet/apps/accounts/summary`)
+  let app_summary = await fetch(`http://localhost:${process.env.NEXT_PORT || process.env.PORT || 3000}/api/v1/mainnet/apps/accounts/summary`)
+
   app_summary = await app_summary.json()
-  let app_total = await fetch(`http://localhost:${process.env.NEXT_PORT || 3000}/api/v1/mainnet/apps/accounts/total?limit=10`)
+  let app_total = await fetch(`http://localhost:${process.env.NEXT_PORT || process.env.PORT || 3000}/api/v1/mainnet/apps/accounts/total?limit=10`)
   app_total = await app_total.json()
-  let apps = await fetch(`http://localhost:${process.env.NEXT_PORT || 3000}/api/v1/mainnet/apps?contract=true`)
+  let apps = await fetch(`http://localhost:${process.env.NEXT_PORT || process.env.PORT || 3000}/api/v1/mainnet/apps?contract=true`)
   apps = await apps.json()
   if (!total_accounts || !app_summary || !app_total || !apps) {
     return {

--- a/server.js
+++ b/server.js
@@ -522,9 +522,9 @@ app.prepare().then(async () => {
     return handle(req, res)
   })
 
-  server.listen(process.env.NEXT_PORT || 3000, (err) => {
+  server.listen(process.env.NEXT_PORT || process.env.PORT || 3000, (err) => {
     if (err) throw err
-    console.log(`NEAR Analytics API listening at http://localhost:${process.env.NEXT_PORT || 3000}`)
+    console.log(`NEAR Analytics API listening at http://localhost:${process.env.NEXT_PORT || process.env.PORT || 3000}`)
   })
 
 })


### PR DESCRIPTION
@neil-oliver Will this break your current deployment or is it fine to use `PORT` instead of `NEXT_PORT`?