### PR TITLE
Filter App Total and Growth API endpoints by Entity_id

### DIFF
--- a/server.js
+++ b/server.js
@@ -208,7 +208,7 @@ app.prepare().then(async () => {
     // extracting a limit parameter from the the url
     const { network } = req.params
 
-    const app = req.query.app ? req.query.app : null
+    const app = req.query.app ? req.query.app.replace(/[&\/\\#,+()$~%.'"^:*?<>{}]/g, '').split(" ")[0] : null
     const contract = req.query.contract ? req.query.contract : false // must have contract_ids
 
     // dates split to create postgres format
@@ -256,7 +256,7 @@ app.prepare().then(async () => {
     const start = req.query.start ? new Date(req.query.start) : new Date(0) // start of EPOCH
     const end = req.query.end ? new Date(req.query.end) : new Date() // now
     const limit = req.query.limit ? `limit ${parseInt(req.query.limit)}` : ""
-    const app = req.query.app ? `WHERE entity_id = '${req.query.app}'` : ""
+    const app = req.query.app ? `WHERE entity_id = '${req.query.app.replace(/[&\/\\#,+()$~%.'"^:*?<>{}]/g, '').split(" ")[0]}'` : ""
 
     // dates split to create postgres format
     let query = `
@@ -347,7 +347,7 @@ app.prepare().then(async () => {
     const start = req.query.start ? new Date(req.query.start) : new Date('2020-09-15') // start of EPOCH
     const end = req.query.end ? new Date(req.query.end) : new Date() // now
     const limit = req.query.limit ? `limit ${parseInt(req.query.limit)}` : ""
-    const app = req.query.app ? `WHERE entity_id = '${req.query.app}'` : ""
+    const app = req.query.app ? `WHERE entity_id = '${req.query.app.replace(/[&\/\\#,+()$~%.'"^:*?<>{}]/g, '').split(" ")[0]}'` : ""
 
     // dates split to create postgres format
     let query = `

--- a/server.js
+++ b/server.js
@@ -256,6 +256,7 @@ app.prepare().then(async () => {
     const start = req.query.start ? new Date(req.query.start) : new Date(0) // start of EPOCH
     const end = req.query.end ? new Date(req.query.end) : new Date() // now
     const limit = req.query.limit ? `limit ${parseInt(req.query.limit)}` : ""
+    const app = req.query.app ? `WHERE entity_id = '${req.query.app}'` : ""
 
     // dates split to create postgres format
     let query = `
@@ -273,6 +274,7 @@ app.prepare().then(async () => {
          entity_id
        FROM
          daily_new_accounts_per_ecosystem_entity_count
+       ${app}
      ),
      entity_series AS (
        SELECT
@@ -345,6 +347,7 @@ app.prepare().then(async () => {
     const start = req.query.start ? new Date(req.query.start) : new Date('2020-09-15') // start of EPOCH
     const end = req.query.end ? new Date(req.query.end) : new Date() // now
     const limit = req.query.limit ? `limit ${parseInt(req.query.limit)}` : ""
+    const app = req.query.app ? `WHERE entity_id = '${req.query.app}'` : ""
 
     // dates split to create postgres format
     let query = `
@@ -362,6 +365,7 @@ app.prepare().then(async () => {
         entity_id
       FROM
         daily_new_accounts_per_ecosystem_entity_count
+        ${app}
     ),
     entity_series AS (
       SELECT


### PR DESCRIPTION
Additional filter added to two endpoints. These filters are not used directly by the NEAR Stats dashboard, but are useful for data validity checks by the Ecosystem team.

example endpoint with filter `/api/v1/mainnet/apps/accounts/total?app=astro-dao`